### PR TITLE
chore: remove Discord links

### DIFF
--- a/templates/welcome.html
+++ b/templates/welcome.html
@@ -13,10 +13,6 @@
       Documentation
     </a>
 
-    <a href="https://discord.gg/HEQBAbTXt2" class="px-3 py-2 hover:text-indigo-700">
-      Join Discord Community
-    </a>
-
     <a href="https://github.com/MasoniteFramework/masonite" class="px-3 py-2 hover:text-indigo-700">
       GitHub
     </a>


### PR DESCRIPTION
Removes links to the Discord community, which is no longer available.